### PR TITLE
add github link

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2,6 +2,7 @@
     {
         "Name": "gotham-colors",
         "Description": "A very dark colorscheme",
+        "Website": "https://github.com/novln/micro-gotham-colors",
         "Tags": [
             "gotham",
             "colors",


### PR DESCRIPTION
This adds the github link so that the repo can be found from the [plugin page](https://micro-editor.github.io/plugins.html).